### PR TITLE
점수 표기 #3

### DIFF
--- a/Assets/Prefabs/alarmText.prefab
+++ b/Assets/Prefabs/alarmText.prefab
@@ -1,0 +1,149 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &108424779446745554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1297868551814415173}
+  - component: {fileID: 4943754115454911492}
+  - component: {fileID: 4698132237853244328}
+  - component: {fileID: -2186041822087415747}
+  m_Layer: 0
+  m_Name: alarmText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1297868551814415173
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108424779446745554}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 49.999672, y: 49.999672, z: 9.999719}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 11.179, y: 2.042}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4943754115454911492
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108424779446745554}
+  m_CullTransparentMesh: 1
+--- !u!114 &4698132237853244328
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108424779446745554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 26e3776e09b37ba48928c54d31e7de9c, type: 2}
+  m_sharedMaterial: {fileID: 4165456676703840452, guid: 26e3776e09b37ba48928c54d31e7de9c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 1
+  m_fontSizeBase: 1
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &-2186041822087415747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 108424779446745554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44341b1b4e6bd5f4c83ebe269dcc7ebf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/alarmText.prefab.meta
+++ b/Assets/Prefabs/alarmText.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0a6cc05e76494434e8fc50246283ca03
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -528,6 +528,7 @@ MonoBehaviour:
   coinScore: 500
   enemyDmg: 0.1
   enemyDownScore: 250
+  alarmText: {fileID: 108424779446745554, guid: 0a6cc05e76494434e8fc50246283ca03, type: 3}
 --- !u!1 &1174143108
 GameObject:
   m_ObjectHideFlags: 0
@@ -858,7 +859,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2.9, y: 0.782}
+  m_AnchoredPosition: {x: 2.9, y: 0.78200006}
   m_SizeDelta: {x: 11.179, y: 2.042}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1955961485

--- a/Assets/Scripts/CollisionManager.cs
+++ b/Assets/Scripts/CollisionManager.cs
@@ -10,14 +10,14 @@ public class CollisionManager : MonoBehaviour
     public float enemyDmg;
     public int enemyDownScore;
 
-    //public GameObject alarmText;
-   // private TMP_Text alarmText_text;
-    //public Vector3 playerPosition;
+    public GameObject alarmText;
+    private TMP_Text alarmText_text;
+    private Vector3 playerPosition;
 
     private void Awake()
     {
-       // alarmText_text = alarmText.GetComponent<TMP_Text>();
-        //playerPosition = gameObject.transform.position;
+       alarmText_text = alarmText.GetComponent<TMP_Text>();
+       playerPosition = gameObject.transform.position;
     }
     private void OnTriggerEnter2D(Collider2D collision)
     {
@@ -31,7 +31,7 @@ public class CollisionManager : MonoBehaviour
         else if (collision.tag == "Coin")
         {
             score_UI.score += coinScore;
-           //AlarmTextShow("+"+coinScore.ToString());
+            AlarmTextShow("+"+coinScore.ToString(),false);
             Destroy(collision.gameObject);
         }
 
@@ -39,14 +39,18 @@ public class CollisionManager : MonoBehaviour
         {
             Battery_UI.battery_meter_value -= enemyDmg;
             score_UI.score -= enemyDownScore;
-            //AlarmTextShow("-"+enemyDownScore.ToString());
+            AlarmTextShow("-"+enemyDownScore.ToString(), true);
             Destroy(collision.gameObject);
         }
     }
 
-   /* private void AlarmTextShow(string number)
+    private void AlarmTextShow(string number, bool enemy)
     {
-        alarmText = Instantiate(alarmText, gameObject.transform.position, Quaternion.identity,GameObject.FindGameObjectWithTag("Canvas").transform) as GameObject;
-        alarmText.GetComponent<TMP_Text>().text = number.ToString();
-    }*/
+        var alarmtext = Instantiate(alarmText, gameObject.transform.position, Quaternion.identity,GameObject.FindGameObjectWithTag("Canvas").transform) as GameObject;
+        alarmtext.GetComponent<TMP_Text>().text = number.ToString();
+        if (enemy) 
+            alarmtext.GetComponent<TMP_Text>().color = Color.red;
+        else
+            alarmtext.GetComponent<TMP_Text>().color = Color.white;
+    }
 }

--- a/Assets/Scripts/alarmtext_delete.cs
+++ b/Assets/Scripts/alarmtext_delete.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class alarmtext_delete : MonoBehaviour
+{
+    private TMP_Text alarmText_text;
+    private Color alarmText_color;
+    void Start()
+    {
+        alarmText_text = gameObject.GetComponent<TMP_Text>();
+        StartCoroutine(fadeText());
+    }
+
+    void Update()
+    {
+        transform.Translate(Vector3.up * Time.deltaTime);
+        
+    }
+
+    private IEnumerator fadeText()
+    {
+        while (alarmText_text.alpha > 0)
+        {
+            alarmText_text.alpha -= 0.1f;
+            yield return new WaitForSeconds(0.1f);
+        }
+
+        Destroy(gameObject);
+    }
+
+}

--- a/Assets/Scripts/alarmtext_delete.cs.meta
+++ b/Assets/Scripts/alarmtext_delete.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44341b1b4e6bd5f4c83ebe269dcc7ebf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -140,7 +140,7 @@
         "com.unity.2d.spriteshape": "9.0.2",
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.2d.tilemap.extras": "3.1.2",
-        "com.unity.2d.aseprite": "1.1.2"
+        "com.unity.2d.aseprite": "1.1.3"
       }
     },
     "com.unity.ide.rider": {


### PR DESCRIPTION
**커밋 b547488** 
Enemy 태그와 Coin 태그에 충돌 시 생기는 점수 변화를 추가 UI로 시각화
alarmtext_delete.cs #C 파일 스크립트 생성

**alarmtext_delete :** 점수 변동이 캐릭터 위치에 표시된 후 서서히 위로 상승하며 투명해진 후 파괴됨
CollisionManager : 추가사항

각각 오브젝트에 해당되는 점수 변동이 UI canvas에 생성되도록 함.
충돌한 오브젝트의 태그에 따라 붉은색(감소) 혹은 흰색(추가)로 차이를 둠
