### PR TITLE
Quick enhancement#24

### DIFF
--- a/Assets/Prefabs/rock.prefab
+++ b/Assets/Prefabs/rock.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5226362929455409994}
   m_Layer: 0
   m_Name: rock
-  m_TagString: Enemy
+  m_TagString: Rock
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/trail.prefab
+++ b/Assets/Prefabs/trail.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5226362929455409994}
   m_Layer: 0
   m_Name: trail
-  m_TagString: Trail
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/water.prefab
+++ b/Assets/Prefabs/water.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5226362929455409994}
   m_Layer: 0
   m_Name: water
-  m_TagString: Enemy
+  m_TagString: Water
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -226,6 +226,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0316a252380484548a3adec045e49fef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  multiplier: 2
   resultScreen: {fileID: 7716232671269070474, guid: 713c0e4f87ed19d448b5ef100b3b6de8, type: 3}
 --- !u!4 &150043692
 Transform:
@@ -485,7 +486,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17eedbd38fcc322428c85c6e2e00d759, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 3
   Trail: {fileID: 4952501761517843183, guid: 261ea08fc7391fb4a87c07eeeac068ba, type: 3}
   TrailTransform: {fileID: 663291210}
 --- !u!212 &663291209
@@ -1275,7 +1275,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 10
   scoreText: {fileID: 1955961485}
-  digger: {fileID: 663291208}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -209,9 +209,6 @@ GameObject:
   - component: {fileID: 150043691}
   m_Layer: 0
   m_Name: GameManager
-  - component: {fileID: 141900600}
-  m_Layer: 0
-  m_Name: TrailTransform
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -393,6 +390,68 @@ MonoBehaviour:
   - {fileID: 4952501761517843183, guid: e70bf48fb13f5944e8231e338a0ce8f5, type: 3}
   - {fileID: 4952501761517843183, guid: e8b079d839a8ddc4e950d3c8a0a77686, type: 3}
   SpawnInterval: 1.5
+--- !u!1 &296821020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 296821021}
+  m_Layer: 0
+  m_Name: Trails
+  m_TagString: Trail
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &296821021
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 296821020}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &341665417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 341665418}
+  m_Layer: 0
+  m_Name: Obstacles
+  m_TagString: Obstacle
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &341665418
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 341665417}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.06619573, y: -0.31506273, z: 0.04814806}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &663291207
 GameObject:
   m_ObjectHideFlags: 0
@@ -428,7 +487,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 3
   Trail: {fileID: 4952501761517843183, guid: 261ea08fc7391fb4a87c07eeeac068ba, type: 3}
-  TrailTransform: {fileID: 141900600}
+  TrailTransform: {fileID: 663291210}
 --- !u!212 &663291209
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -493,8 +552,7 @@ Transform:
   m_LocalPosition: {x: -0.35, y: 2.97, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 141900600}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &663291211
@@ -1228,3 +1286,5 @@ SceneRoots:
   - {fileID: 260981007}
   - {fileID: 2061039579}
   - {fileID: 150043692}
+  - {fileID: 296821021}
+  - {fileID: 341665418}

--- a/Assets/Scripts/Background.cs
+++ b/Assets/Scripts/Background.cs
@@ -4,11 +4,12 @@ using UnityEngine;
 
 public class NewBehaviourScript : MonoBehaviour
 {
-    private float speed = 3f;
     // Update is called once per frame
     void Update()
     {
         if(!GameManager.Game_Over)
-               transform.position += Vector3.up * speed * Time.deltaTime;
+               transform.position += Vector3.up * GameManager.speed * Time.deltaTime;
+
     }
+
 }

--- a/Assets/Scripts/Battery_UI.cs
+++ b/Assets/Scripts/Battery_UI.cs
@@ -21,6 +21,11 @@ public class Battery_UI : MonoBehaviour
         StartCoroutine(BatteryDown());
     }
 
+    private void Update()
+    {
+        if (battery_meter_value < 0) GameManager.Game_Over = true;
+    }
+
     private IEnumerator BatteryDown()
     {
         while (true)

--- a/Assets/Scripts/CollisionManager.cs
+++ b/Assets/Scripts/CollisionManager.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class CollisionManager : MonoBehaviour
 {
+    public static bool hit_rock;
+
     public float oilAddValue;
     public int coinScore;
     public float enemyDmg;
@@ -18,6 +20,7 @@ public class CollisionManager : MonoBehaviour
     {
        alarmText_text = alarmText.GetComponent<TMP_Text>();
        playerPosition = gameObject.transform.position;
+        hit_rock = false;
     }
     private void OnTriggerEnter2D(Collider2D collision)
     {
@@ -39,11 +42,27 @@ public class CollisionManager : MonoBehaviour
 
             else if (collision.tag == "Enemy")
             {
-                Battery_UI.battery_meter_value -= enemyDmg;
+                GameManager.Game_Over = true;
+            }
+
+            else if (collision.tag == "Water" || collision.tag == "Rock")
+            {
                 //Debug.Log(Battery_UI.battery_meter_value);
                 score_UI.score -= enemyDownScore;
                 AlarmTextShow("-" + enemyDownScore.ToString(), true);
+
+                if (collision.tag == "Water")
+                {
+                    Battery_UI.battery_meter_value -= enemyDmg;
+                }
+
+                else if (collision.tag == "Rock")
+                {
+                    hit_rock = true;
+                }
+
                 Destroy(collision.gameObject);
+
             }
         }
     }

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -44,6 +44,6 @@ public class Enemyspawner : MonoBehaviour
     void SpawnEnemy(float posx, int index)
     {
         Vector3 spawnPos = new Vector3(posx, transform.position.y, transform.position.z);
-        Instantiate(enemies[index], spawnPos, Quaternion.identity);
+        Instantiate(enemies[index], spawnPos, Quaternion.identity, GameObject.FindGameObjectWithTag("Obstacle").transform);
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,21 +1,42 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
     public static bool Game_Over;
+    private bool flag = false;
+
+    public static float speed;
+    public float multiplier;
 
     public GameObject resultScreen;
 
+    private void Start()
+    {
+        flag = false;
+        speed = 3f;
+    }
     void Update()
     {
-        if (Battery_UI.battery_meter_value <= 0 && !Game_Over)
+        if (Game_Over && !flag)
         {
-            Game_Over = true;
+            flag = true;
             var ResultScreen = Instantiate(resultScreen, gameObject.transform.position, Quaternion.identity, GameObject.FindGameObjectWithTag("Canvas").transform) as GameObject;
             //Debug.Log("Game Over" + Battery_UI.battery_meter_value);
         }
+
+        if (CollisionManager.hit_rock)
+            StartCoroutine(slowDown());
             
+    }
+
+    private IEnumerator slowDown()
+    {
+        CollisionManager.hit_rock = false;
+        speed /= multiplier; 
+        yield return new WaitForSeconds(3f);
+        speed *= multiplier;
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -28,7 +28,7 @@ public class Player : MonoBehaviour
     }
 
     void TrailRoutine(){
-        Instantiate(Trail, TrailTransform.position, Quaternion.identity);
+        Instantiate(Trail, TrailTransform.position, Quaternion.identity, GameObject.FindGameObjectWithTag("Trail").transform);
     }
     
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -6,13 +6,11 @@ using UnityEngine;
 public class Player : MonoBehaviour
 {
     [SerializeField]
-
-    public float speed = 3f;
-    [SerializeField]
     private GameObject Trail;
     [SerializeField]
     private Transform TrailTransform;
-    // Update is called once per frame
+
+
     void Update()
     {
     
@@ -20,7 +18,7 @@ public class Player : MonoBehaviour
         {
             float horizontalInput = Input.GetAxisRaw("Horizontal");
             Vector3 moveTo = new Vector3(horizontalInput, 0f, 0f);
-            transform.position += moveTo * speed * Time.deltaTime;
+            transform.position += moveTo * GameManager.speed * Time.deltaTime;
 
             TrailRoutine();
         }
@@ -31,4 +29,5 @@ public class Player : MonoBehaviour
         Instantiate(Trail, TrailTransform.position, Quaternion.identity, GameObject.FindGameObjectWithTag("Trail").transform);
     }
     
+
 }

--- a/Assets/Scripts/ResultManager.cs
+++ b/Assets/Scripts/ResultManager.cs
@@ -19,7 +19,7 @@ public class ResultManager : MonoBehaviour
     }
     void Start()
     {
-        scoretext.text = "Score: " + score_UI.score.ToString();
+        scoretext.text = "Score: " + ((int)score_UI.score).ToString();
     }
 
     void Update()

--- a/Assets/Scripts/obstacle.cs
+++ b/Assets/Scripts/obstacle.cs
@@ -6,15 +6,13 @@ public class Mole : MonoBehaviour
 {
     [SerializeField]
 
-    private float speed = 3f;
-
     private float maxY = 6;
     // Update is called once per frame
     void Update()
     {
         if (!GameManager.Game_Over)
         {
-            transform.position += Vector3.up * speed * Time.deltaTime;
+            transform.position += Vector3.up * GameManager.speed * Time.deltaTime;
             if (transform.position.y > maxY)
             {
                 Destroy(gameObject);

--- a/Assets/Scripts/score_UI.cs
+++ b/Assets/Scripts/score_UI.cs
@@ -8,17 +8,13 @@ public class score_UI : MonoBehaviour
 {
 
     public static float score = 0;
-    private float speed;
     public float multiplier;
 
     public TMP_Text scoreText;
 
-    public Player digger;
-
     private void Awake()
     {
         score = 0;
-        speed = digger.speed;
     }
     void Start()
     {
@@ -30,8 +26,8 @@ public class score_UI : MonoBehaviour
     {
         while (!GameManager.Game_Over)
         {
-            score += (speed*multiplier);
-            scoreText.text = score.ToString();
+            score += (GameManager.speed*multiplier);
+            scoreText.text = ((int)score).ToString();
             yield return new WaitForSeconds(0.1f);
         }
         

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - Oil
   - Canvas
   - Trail
+  - Obstacle
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -10,6 +10,8 @@ TagManager:
   - Canvas
   - Trail
   - Obstacle
+  - Water
+  - Rock
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
**커밋 590a64b** 
플레이어 경로에 생성되는 오브젝트(trail)과 각종 장애물(두더지, 동전, 물, 돌)이 Hierarchy에 바로 생성되는 것이 아닌 각각 배정된 오브젝트의 하위 오브젝트로 생성되도록 변경, 정리
Trail prefab에서 사용되지 않던 trail 태그를 새 상위 오브젝트의 태그로 사용
Obstacle 태그 추가

**EnemySpawner :** 변경사항
	장애물 오브젝트가 생성될 때 Obstacle 태그가 배정된 오브젝트의 하위 오브젝트가 되도록 함

**Player:** 변경사항
	Trail 오브젝트가 생성될 때 trail 태그가 배정된 오브젝트의 하위 오브젝트가 되도록 함


**커밋 9c6e9fa** 
두더지, 돌, 물 오브젝트가 충돌 시 각각 다른 효과가 나오도록 변경
돌과 물 오브젝트의 태그를 각각 Rock과 Water로 추가, 변경
Player, Background, obstacle, score_UI 스크립트에 분산되어 있던 이동속도 변수를 GameManager의 static 변수로 변경, 일관화

**CollisionManager :** 추가, 변경사항
	hit_rock : static 변수. Tag가 Rock인 오브젝트에 충돌 시 true가 됨.
	두더지 충돌 시 게임 오버
	물, 돌 충돌 시 점수 감소
	물 충돌 시에만 배터리 잔량 감소

**ResultManager, score_UI :** 변경사항
	돌 충돌 감속 시 speed가 1.5f가 됨에 따라 점수에 소수점이 생길 여지가 있어 시각화 과정에서 int형변환을 거쳐 소수점을 버리도록 함

**Battery_UI :** 변경사항
	게임 오버 조건이 추가됨에 따라 GameManager에서 배터리 잔량을 받아오는 것이 아니라 본 스크립트 내에서 게임오버 여부를 판독하도록 변경

**GameManager :** 변경사항
	본 스크립트 내에서 자체적으로 배터리 잔량 게임 오버를 판독하지 않음
	게임 오버 후 진행되는 과정만을 일임
	speed : static 변수. 이동하는 모든 오브젝트가 자신의 속도로 해당 변수를 가져옴.
	multiplier : 2f (hit_rock static 변수를 받아와 true일 시 speed를 multiplier만큼 나눴다가 3초 후 다시 곱해 정상화)
