### PR TITLE
게임 시작 화면 추가#27

### DIFF
--- a/Assets/Prefabs/resultScreen.prefab
+++ b/Assets/Prefabs/resultScreen.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 103094931634488235}
   - component: {fileID: 5512669714742440814}
   m_Layer: 0
-  m_Name: scoreText
+  m_Name: sub_txt1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -337,6 +337,7 @@ RectTransform:
   - {fileID: 3924310950558981193}
   - {fileID: 2180217361502628908}
   - {fileID: 1987130168671615227}
+  - {fileID: 207072961839151600}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -396,7 +397,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 15
   dif: 10
-  scoretext: {fileID: 5512669714742440814}
+  mainText: {fileID: 852723047896319938}
+  subText1: {fileID: 5512669714742440814}
+  subText2: {fileID: 7767462549748874169}
+  StartText:
+  - Game Start
+  - Click to start
+  OverText:
+  - Game Over
+  - Click to restart
 --- !u!1 &8108838691378450555
 GameObject:
   m_ObjectHideFlags: 0
@@ -409,7 +418,7 @@ GameObject:
   - component: {fileID: 2753249366302396547}
   - component: {fileID: 852723047896319938}
   m_Layer: 0
-  m_Name: gameover_txt
+  m_Name: Title_txt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -496,8 +505,142 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 4
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -2.135622, y: 0, z: -1.8915482, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &9009032831996467160
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207072961839151600}
+  - component: {fileID: 3805610349117680358}
+  - component: {fileID: 7767462549748874169}
+  m_Layer: 0
+  m_Name: sub_txt2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &207072961839151600
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009032831996467160}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.83332783, y: 0.83332783, z: 9.999718}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8046961475278090570}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -3.63}
+  m_SizeDelta: {x: 11.179, y: 2.042}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3805610349117680358
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009032831996467160}
+  m_CullTransparentMesh: 1
+--- !u!114 &7767462549748874169
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009032831996467160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Click to restart
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 26e3776e09b37ba48928c54d31e7de9c, type: 2}
+  m_sharedMaterial: {fileID: 4165456676703840452, guid: 26e3776e09b37ba48928c54d31e7de9c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 1
+  m_fontSizeBase: 1
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -228,6 +228,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 2
   resultScreen: {fileID: 7716232671269070474, guid: 713c0e4f87ed19d448b5ef100b3b6de8, type: 3}
+  player: {fileID: 663291207}
+  battery: {fileID: 1174143108}
+  scoreboard: {fileID: 2122787026}
+  spawner: {fileID: 260981006}
 --- !u!4 &150043692
 Transform:
   m_ObjectHideFlags: 0
@@ -356,7 +360,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &260981007
 Transform:
   m_ObjectHideFlags: 0
@@ -473,7 +477,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &663291208
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -654,7 +658,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1174143109
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1188,7 +1192,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2122787027
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Background.cs
+++ b/Assets/Scripts/Background.cs
@@ -7,7 +7,7 @@ public class NewBehaviourScript : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if(!GameManager.Game_Over)
+        if(!GameManager.Game_Over && GameManager.Game_Start)
                transform.position += Vector3.up * GameManager.speed * Time.deltaTime;
 
     }

--- a/Assets/Scripts/Battery_UI.cs
+++ b/Assets/Scripts/Battery_UI.cs
@@ -28,7 +28,7 @@ public class Battery_UI : MonoBehaviour
 
     private IEnumerator BatteryDown()
     {
-        while (true)
+        while (!GameManager.Game_Over)
         {
             if (battery_meter_value > 1) battery_meter_value = 1;
             battery_meter_value -= downAmount;

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -23,7 +23,7 @@ public class Enemyspawner : MonoBehaviour
     IEnumerator EnemyRoutine() {
         yield return new WaitForSeconds(2f);
         // 적 무한 생성 반복
-        while (!GameManager.Game_Over){ 
+        while (!GameManager.Game_Over && GameManager.Game_Start){ 
             // 같은 곳에서의 중복 생성 확인
             int[] flag = {0, 0, 0, 0, 0, 0, 0, 0, 0};
             // 최소 3개에서 최대 6개의 적 생성

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -6,17 +6,28 @@ using UnityEngine;
 public class GameManager : MonoBehaviour
 {
     public static bool Game_Over;
+    public static bool Game_Start;
     private bool flag = false;
+    private bool enabled = false;
 
     public static float speed;
     public float multiplier;
 
     public GameObject resultScreen;
 
+    public GameObject player, battery, scoreboard, spawner;
+
     private void Start()
     {
         flag = false;
+        enabled = false;
         speed = 3f;
+
+        if (!Game_Start)
+        {
+            var ResultScreen = Instantiate(resultScreen, gameObject.transform.position, Quaternion.identity, GameObject.FindGameObjectWithTag("Canvas").transform) as GameObject;
+        }
+
     }
     void Update()
     {
@@ -29,6 +40,15 @@ public class GameManager : MonoBehaviour
 
         if (CollisionManager.hit_rock)
             StartCoroutine(slowDown());
+
+        if (Game_Start && !enabled)
+        {
+            enabled = true;
+            player.active = true;
+            battery.active = true;
+            scoreboard.active = true;
+            spawner.active = true;
+        }
             
     }
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -14,7 +14,7 @@ public class Player : MonoBehaviour
     void Update()
     {
     
-        if(!GameManager.Game_Over)
+        if(!GameManager.Game_Over && GameManager.Game_Start)
         {
             float horizontalInput = Input.GetAxisRaw("Horizontal");
             Vector3 moveTo = new Vector3(horizontalInput, 0f, 0f);

--- a/Assets/Scripts/ResultManager.cs
+++ b/Assets/Scripts/ResultManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static UnityEngine.GraphicsBuffer;
@@ -11,15 +12,33 @@ public class ResultManager : MonoBehaviour
     public float speed;
     public int dif;
 
-    public TMP_Text scoretext;
+    public TMP_Text mainText, subText1, subText2;
     private bool moveFinished = false;
+
+    public string[] StartText, OverText;
+
     private void Awake()
     {
         targetPos = Vector3.zero;
     }
     void Start()
     {
-        scoretext.text = "Score: " + ((int)score_UI.score).ToString();
+        moveFinished = false;
+
+        if (GameManager.Game_Over)
+        {
+            mainText.text = OverText[0];
+            subText1.text = "Score: " + ((int)score_UI.score).ToString();
+            subText2.text = OverText[1];
+        }
+
+        else
+        {
+            mainText.text = StartText[0];
+            subText1.text = " ";
+            subText2.text = StartText[1];
+        }
+        
     }
 
     void Update()
@@ -33,7 +52,6 @@ public class ResultManager : MonoBehaviour
 
         if(Input.GetMouseButtonDown(0) && moveFinished)
         {
-           
            StartCoroutine(Reset());
         }
          
@@ -44,8 +62,20 @@ public class ResultManager : MonoBehaviour
         yield return StartCoroutine(moveDown());
         score_UI.score = 0;
         Battery_UI.battery_meter_value = 1;
-        GameManager.Game_Over = false;
-        SceneManager.LoadScene("main");
+
+        if (GameManager.Game_Over)
+        {
+            GameManager.Game_Over = false;
+            SceneManager.LoadScene("main");
+        }
+
+        else
+        {
+            GameManager.Game_Start = true;
+            Destroy(gameObject);
+        }
+            
+        
     }
 
     private IEnumerator moveDown()

--- a/Assets/Scripts/obstacle.cs
+++ b/Assets/Scripts/obstacle.cs
@@ -10,7 +10,7 @@ public class Mole : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (!GameManager.Game_Over)
+        if (!GameManager.Game_Over && GameManager.Game_Start)
         {
             transform.position += Vector3.up * GameManager.speed * Time.deltaTime;
             if (transform.position.y > maxY)

--- a/Assets/Scripts/score_UI.cs
+++ b/Assets/Scripts/score_UI.cs
@@ -24,7 +24,7 @@ public class score_UI : MonoBehaviour
 
     private IEnumerator scoreAdd()
     {
-        while (!GameManager.Game_Over)
+        while (!GameManager.Game_Over && GameManager.Game_Start)
         {
             score += (GameManager.speed*multiplier);
             scoreText.text = ((int)score).ToString();


### PR DESCRIPTION
**커밋 0101f76**
게임 오버용 UI를 활용해 게임 최초 시작 시에도 유사 UI가 생성되도록 변경
score_UI, Player, obstacle, EnemySpawner, Background, Battery_UI : 변경사항
게임 시작 UI가 활성화된 동안 주요 기능 정지

**ResultManager :** 추가, 변경사항
		게임 오버 및 시작 UI의 텍스트를 prefab에 저장하지 않고 스크립트 내 리스트로 저장하여 상황에 맞게 출력할 수 있도록 변경
